### PR TITLE
Fix tar file modes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,6 +301,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <tarLongFileMode>posix</tarLongFileMode>
                     <descriptors>
                         <descriptor>assembly/assembly-jar-with-dependencies.xml</descriptor>
                         <descriptor>assembly/assembly-distribution.xml</descriptor>


### PR DESCRIPTION
This is a fix for issue #12 

Problem building as user with a very high group id number.

The solution is to use posix mode as noted in  [maven-assembly-plugin doc](https://maven.apache.org/plugins/maven-assembly-plugin/faq.html#tarFileModes)  :

> **Tar complains about groupid value being too big**
> 
> GNU tar has restrictions on max value of UID/GUID in tar files. Consider using the more well defined POSIX tar format, which should support larger values. Use tarLongFileMode=posix in the assembly:single goal. 
